### PR TITLE
Bugfix: Scalar String Datasets and Empty Datasets h5parse.py Crash

### DIFF
--- a/h5parse.py
+++ b/h5parse.py
@@ -18,27 +18,32 @@ def meta_dict(obj) -> dict:
                 }
     elif isinstance(obj, h5py.Dataset):
         shape = "scalar"
+        datarange = ""
+        dtype = "object" # h5py call non-numeric types object
         data  = obj[()]
-        if data.shape is not None:
+        if hasattr(data, "dtype"):
+            dtype = str(data.dtype)
+        if (hasattr(data, "shape") and
+            data.shape is not None and
+            dtype != "object"):
             datavec = data.reshape(-1) # data as a vector
             if len(data.shape) > 0:
                 shape = str(data.shape)
-            try: # calculate the data range
-                datamin = np.nanmin(datavec)
-                datamax = np.nanmax(datavec)
-                if datamin == datamax:
-                    datarange = f'{datamin:.4g}'
-                else:
-                    datarange = f'{datamin:.3g}:{datamax:.3g}'
-            except: # take the 1st value if it's something weird
-                datarange = str(datavec[0])
-        else:
-            datarange = ""
+            if len(datavec) > 0: # Protect against empty datasets
+                try: # calculate the data range
+                    datamin = np.nanmin(datavec)
+                    datamax = np.nanmax(datavec)
+                    if datamin == datamax:
+                        datarange = f'{datamin:.4g}'
+                    else:
+                        datarange = f'{datamin:.3g}:{datamax:.3g}'
+                except: # take the 1st value if it's something weird
+                    datarange = str(datavec[0])
         meta =  {'type': 'dataset',
                  'name': obj.name,
                  'shape': shape,
                  'range': datarange,
-                 'dtype': str(data.dtype)}
+                 'dtype': dtype}
     else:
         raise Exception(f"'{obj.name}' is not a dataset or group")
     return meta


### PR DESCRIPTION
h5parse.py currently throws an exception parsing files that contain scalar string datasets or empty datasets. Here's how you can create a problematic file from python with h5py:

`
import h5py

f1 = h5py.File('string.h5', mode='w')
f1['strval'] = 'foobar'

f2 = h5py.File('empty.h5', mode='w')
f2['emptyval'] = []
`

Output:

`
paul@sisko[hdf5-viewer](dev)$ ./h5parse.py --get-fields / string.h5 
Traceback (most recent call last):
  File "/home/paul/Repos/hdf5-viewer/./h5parse.py", line 125, in <module>
    print(json.dumps(inst.get_fields(args.get_fields), indent=4))
                     ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/paul/Repos/hdf5-viewer/./h5parse.py", line 60, in get_fields
    fields[cname] = meta_dict(cobj)
                    ~~~~~~~~~^^^^^^
  File "/home/paul/Repos/hdf5-viewer/./h5parse.py", line 22, in meta_dict
    if data.shape is not None:
       ^^^^^^^^^^
AttributeError: 'bytes' object has no attribute 'shape'
`

`paul@sisko[hdf5-viewer](dev)$ ./h5parse.py --get-fields / empty.h5 
Traceback (most recent call last):
  File "/home/paul/Repos/hdf5-viewer/./h5parse.py", line 27, in meta_dict
    datamin = np.nanmin(datavec)
  File "/usr/lib/python3.13/site-packages/numpy/lib/_nanfunctions_impl.py", line 357, in nanmin
    res = np.fmin.reduce(a, axis=axis, out=out, **kwargs)
ValueError: zero-size array to reduction operation fmin which has no identity

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/paul/Repos/hdf5-viewer/./h5parse.py", line 125, in <module>
    print(json.dumps(inst.get_fields(args.get_fields), indent=4))
                     ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/paul/Repos/hdf5-viewer/./h5parse.py", line 60, in get_fields
    fields[cname] = meta_dict(cobj)
                    ~~~~~~~~~^^^^^^
  File "/home/paul/Repos/hdf5-viewer/./h5parse.py", line 34, in meta_dict
    datarange = str(datavec[0])
                    ~~~~~~~^^^
IndexError: index 0 is out of bounds for axis 0 with size 0
`

For some reason, string fields don't return a h5py  object with dtype/shape attributes, they return a bytes object. I updated the meta_dict function to handle this better.