### PR TITLE
make buffer names unique for files with same basename

### DIFF
--- a/hdf5-viewer.el
+++ b/hdf5-viewer.el
@@ -263,9 +263,9 @@ DIRECTION indicates which way we are navigating the heirarchy:
                     hdf5-viewer--forward-point-list nil)
               (hdf5-viewer--display-fields 0)))
         (let* ((output (hdf5-viewer--run-parser "--read-dataset" field hdf5-viewer-file))
-               (parent-buf (format "%s" (current-buffer)))
-               (parent-nostars (substring parent-buf 1 (1- (length parent-buf)))))
-          (with-current-buffer (get-buffer-create (format "*%s%s*" parent-nostars field))
+               (parent-buf (string-split (buffer-name (current-buffer)) "*" t))
+               (dataset-buf (concat "*" (pop parent-buf) field "*" (apply 'concat parent-buf))))
+          (with-current-buffer (get-buffer-create dataset-buf)
             (let ((inhibit-read-only t))
               (erase-buffer)
               (setq-local truncate-lines t)
@@ -309,7 +309,13 @@ buffer named \"*hdf5: FILENAME*\" and start hdf5-viewer.
 
 The WILDCARDS flag is not used by this advice and is passed on to
 `find-file'.  HDF5 files referenced by wildcards will be opened
-as normal files, without `hdf5-viewer'."
+as normal files, without `hdf5-viewer'.
+
+For files with the same nondirectory names, the buffer names are
+disambituated with `generate-new-buffer-name', which appends an
+incrementing \"<#>\" to the buffer name.  The `buffer-file-name'
+is set uniquely, via `set-visited-file-name', to the HDF5
+filename with \"-hdf5-viewer\" appended to the end."
 
   (if (not (file-regular-p filename)) nil
     (let ((hdf5-signature (unibyte-string #x89 #x48 #x44 #x46 #x0d #x0a #x1a #x0a))
@@ -318,23 +324,19 @@ as normal files, without `hdf5-viewer'."
                      (insert-file-contents-literally filename nil 0 8 t)
                      (buffer-substring-no-properties 1 9))))
       (when (string= filehead hdf5-signature)
-        (let ((hdf5-viewer-buffer-name (concat "*hdf5: "
-                                        (file-name-nondirectory filename)
-                                        "*")))
-          ;; for later:
-          ;; if hdf5-viewer-buffer-name corresponds to an existing buffer
-          ;;    if (string= filename hdf5-viewer--buffer-filename)
-          ;;       switch to buffer
-          ;;    else
-          ;;       create/switch to buffer with unique name
-          ;;       setq hdf5-viewer--buffer-filename filename
-          ;;       (hdf5-viewer-mode)
-          ;; else run next 3 lines
-          (switch-to-buffer (get-buffer-create hdf5-viewer-buffer-name));; need to uniquify this name (later)
-          (setq default-directory (file-name-directory filename))
-          (setq hdf5-viewer--buffer-filename filename) ;;hdf5-viewer operates on hdf5-viewer--buffer-filename
-          (hdf5-viewer-mode)
-          t))))) ;; bypass find-file
+        (let* ((this-buffer-filename (concat filename "-hdf5-viewer"))
+               (this-buffer-name (format "*hdf5: %s*" (file-name-nondirectory filename)))
+               (this-buffer (find-buffer-visiting this-buffer-filename)))
+          (if this-buffer
+              (switch-to-buffer this-buffer)
+            (let ((new-buffer-name (generate-new-buffer-name this-buffer-name)))
+              (switch-to-buffer (get-buffer-create new-buffer-name))
+              (setq default-directory (file-name-directory filename))
+              (setq hdf5-viewer--buffer-filename filename)
+              (set-visited-file-name this-buffer-filename)
+              (rename-buffer new-buffer-name)
+              (hdf5-viewer-mode))))
+        t)))) ;; bypass find-file
 
 ;;;###autoload
 (advice-add 'find-file :before-until #'hdf5-viewer-maybe-startup)

--- a/hdf5-viewer.el
+++ b/hdf5-viewer.el
@@ -264,7 +264,7 @@ DIRECTION indicates which way we are navigating the heirarchy:
               (hdf5-viewer--display-fields 0)))
         (let* ((output (hdf5-viewer--run-parser "--read-dataset" field hdf5-viewer-file))
                (parent-buf (string-split (buffer-name (current-buffer)) "*" t))
-               (dataset-buf (concat "*" (pop parent-buf) field "*" (apply 'concat parent-buf))))
+               (dataset-buf (format "*%s%s*%s" (pop parent-buf) field (apply 'concat parent-buf))))
           (with-current-buffer (get-buffer-create dataset-buf)
             (let ((inhibit-read-only t))
               (erase-buffer)


### PR DESCRIPTION
`hdf5-viewer-read-field`: improve buffer name parsing so that dataset field name is properly inserted into the buffer name.  With the disambiguating string after the second *, the old way was failing.

`hdf5-viewer-maybe-startup`: make unique buffer names when multiple files with the same base filename are opened (verify with `test/string.h5` and `test/sub/string.h5`).  The buffers are disambiguated with "<#>" suffixes.  The buffer filename is set to `<full path filename>-hdf5-viewer`, which allows subsequent calls to detect whether this particular file has already been opened.

Verification:
1. Open `test/string.h5`.
2. Type `q` to leave this buffer without closing it.
3. Open `test/sub/string.h5` -- the new buffer for this file should have the suffix `<2>`
4. Leaving either buffer with `q` and then opening the files again should land you in one of the open buffers, not a new one.

One **could** save the buffer to the filename that is set, but the purpose of the buffer filename is only to identify the correct open buffer (if it exists) since the buffer name is not sufficient to identify the underlying file.