### PR TITLE
add global minor mode to allow user to enable/disable this package

### DIFF
--- a/hdf5-viewer.el
+++ b/hdf5-viewer.el
@@ -288,16 +288,22 @@ DIRECTION indicates which way we are navigating the heirarchy:
           (message "Copied HD5 %s name: %s" field-type field-name))
       (message "No field or attribute found on this line."))))
 
-;;;###autoload
 (define-derived-mode hdf5-viewer-mode special-mode "HDF5"
-  "Major mode for viewing HDF5 files."
-  (setq-local buffer-read-only t)
-  (setq-local hdf5-viewer-file hdf5-viewer--buffer-filename)
-  (setq-local hdf5-viewer-root "/")
-  (hdf5-viewer--display-fields 0))
+  "Major mode for viewing HDF5 files.
 
-;;;###autoload
-(defun hdf5-viewer-maybe-startup (&optional filename _wildcards)
+In order to protect HDF5 data file from corruption, enable
+`hdf-viewer-find-file-mode' so that the data file does not
+actually get loaded into a buffer.  This package works by
+interfacing with the HDF5 file via python library calls."
+
+  (if (not hdf5-viewer-find-file-mode)
+      (message "To use this mode, enable `hdf5-viewer-find-file-mode' and reopen the file.")
+    (setq-local buffer-read-only t)
+    (setq-local hdf5-viewer-file hdf5-viewer--buffer-filename)
+    (setq-local hdf5-viewer-root "/")
+    (hdf5-viewer--display-fields 0)))
+
+(defun hdf5-viewer-bypass-find-file (&optional filename _wildcards)
   "Advice to avoid loading HDF5 files into the buffer.
 
 HDF5 files can be very large and `hdf5-viewer' does not need the file
@@ -338,7 +344,12 @@ as normal files, without `hdf5-viewer'."
           t))))) ;; bypass find-file
 
 ;;;###autoload
-(advice-add 'find-file :before-until #'hdf5-viewer-maybe-startup)
+(define-minor-mode hdf5-viewer-find-file-mode
+  "Global minor mode to enable/disable hdf5-viewer-mode."
+  :global     t
+  (if hdf5-viewer-find-file-mode
+      (advice-add 'find-file :before-until #'hdf5-viewer-bypass-find-file)
+    (advice-remove 'find-file #'hdf5-viewer-bypass-find-file)))
 
 (provide 'hdf5-viewer)
 


### PR DESCRIPTION
New minor mode is `hdf5-viewer-find-file-mode` as suggested by @riscy (MELPA).

`hdf5-viewer-maybe-startup` has been renamed to `hdf5-viewer-bypass-find-file`, as that better describes the action of the `find-file` advice.

`hdf5-viewer-mode` has been altered to issue a message to the user and exit if `hdf5-viewer-find-file-mode` is not enabled.  I think this is necessary because of the precautions taken in `...-bypass-find-file` to protect the raw data file from corruption.